### PR TITLE
Update extension documentation link in index.jelly

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,5 +3,5 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  Allow to define a list of <a href="https://wiki.jenkins-ci.org/display/JENKINS/Extension+points">extensions</a> to be disabled on this instance.
+  Allow to define a list of <a href="https://jenkins.io/doc/developer/extensions/">extensions</a> to be disabled on this instance.
 </div>


### PR DESCRIPTION
The documentation has moved to https://jenkins.io/doc/developer/extensions/

...but really this pull request is just an excuse to say thank you. :) We were in a very similar situation where an extension was causing performance issues (https://issues.jenkins-ci.org/browse/JENKINS-40612) and we were not in a place we could update to fix it, and mitigating with this extension brought our page loads down from 5-6 seconds to under 1 second.  So, thanks for sharing this with the world. :)